### PR TITLE
NixOS Flake for the application

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,16 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+
+/.direnv/
+
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -49,3 +49,28 @@ Run the application (vscode):
 - Android Studio (for Android development)
 
 - Xcode (for iOS development, if applicable)
+
+## ❄️ NixOS ❄️
+On NixOS you need to enter the flake using: 
+```nix
+nix develop
+```
+and create an emulator:
+```bash
+avdmanager create avd --force --name phone --package 'system-images;android-32;google_apis;x86_64'
+emulator -avd phone -skin 720x1280 --gpu host
+```
+If it is first time building, then run: 
+```bash
+flutter create .
+```
+If not, then simply use run the emulator using 
+```bash
+flutter emulators --launch phone
+```
+And then run the application, while the emulator is running:
+```bash
+flutter run -d sdk
+```
+
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1740601646,
+        "narHash": "sha256-smo82N8451pc2zK4pdARSPxqUmqVvJ6q8hdxbsVZyw8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "657b2f8cca9d35e4e88e45bffdcfbf795e3e6dc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  description = "Flutter environment";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachSystem ["x86_64-linux"] (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+          android_sdk.accept_license = true;
+        };
+        androidEnv = pkgs.androidenv.override {licenseAccepted = true;};
+        androidComposition = androidEnv.composeAndroidPackages {
+          cmdLineToolsVersion = "9.0"; # emulator related: newer versions are not only compatible with avdmanager
+          platformToolsVersion = "35.0.1"; # "34.0.4"
+          buildToolsVersions = ["30.0.3" "33.0.2" "34.0.0" "33.0.1"];
+          platformVersions = ["28" "31" "32" "33" "34" "35"];
+          abiVersions = ["x86_64"]; # emulator related: on an ARM machine, replace "x86_64" with
+          # either "armeabi-v7a" or "arm64-v8a", depending on the architecture of your workstation.
+          includeNDK = false;
+          includeSystemImages = true; # emulator related: system images are needed for the emulator.
+          systemImageTypes = ["google_apis" "google_apis_playstore"];
+          includeEmulator = true; # emulator related: if it should be enabled or not
+          useGoogleAPIs = true;
+          extraLicenses = [
+            "android-googletv-license"
+            "android-sdk-arm-dbt-license"
+            "android-sdk-license"
+            "android-sdk-preview-license"
+            "google-gdk-license"
+            "intel-android-extra-license"
+            "intel-android-sysimage-license"
+            "mips-android-sysimage-license"
+          ];
+        };
+        androidSdk = androidComposition.androidsdk;
+      in {
+        devShell = with pkgs;
+          mkShell rec {
+            ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
+            ANDROID_SDK_ROOT = "${androidSdk}/libexec/android-sdk";
+            JAVA_HOME = jdk17.home;
+            FLUTTER_ROOT = flutter;
+            DART_ROOT = "${flutter}/bin/cache/dart-sdk";
+            GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidSdk}/libexec/android-sdk/build-tools/34.0.0/aapt2";
+            QT_QPA_PLATFORM = "wayland;xcb"; # emulator related: try using wayland, otherwise fall back to X.
+            # NB: due to the emulator's bundled qt version, it currently does not start with QT_QPA_PLATFORM="wayland".
+            # Maybe one day this will be supported.
+            buildInputs = [
+              androidSdk
+              flutter
+              qemu_kvm
+              gradle
+              jdk17
+            ];
+            # emulator related: vulkan-loader and libGL shared libs are necessary for hardware decoding
+            LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath [vulkan-loader libGL]}";
+            # Globally installed packages, which are installed through `dart pub global activate package_name`,
+            # are located in the `$PUB_CACHE/bin` directory.
+            shellHook = ''
+              if [ -z "$PUB_CACHE" ]; then
+                export PATH="$PATH:$HOME/.pub-cache/bin"
+              else
+                export PATH="$PATH:$PUB_CACHE/bin"
+              fi
+            '';
+          };
+      }
+    );
+}


### PR DESCRIPTION
This pull request introduces support for NixOS and adds a `flake.nix` configuration to set up the Flutter development environment. Key changes include updates to the `.envrc` file, the `README.md` file, and the addition of a new `flake.nix` file.

NixOS support:

* [`.envrc`](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430R1): Added `use flake` to enable the use of Nix flakes.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R76): Added instructions for setting up and running the application on NixOS, including commands for entering the flake, creating an emulator, and running the Flutter application.

Flutter environment configuration:

* [`flake.nix`](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R1-R79): Introduced a new `flake.nix` file to configure the Flutter development environment using Nix. This includes setting up Android SDK, Flutter, and other necessary tools and dependencies.